### PR TITLE
Rename App class to avoid conflict with Revit API Application

### DIFF
--- a/source/Nice3point.Revit.AddIn.Application/App.cs
+++ b/source/Nice3point.Revit.AddIn.Application/App.cs
@@ -11,7 +11,7 @@ namespace Nice3point.Revit.AddIn;
 ///     Application entry point
 /// </summary>
 [UsedImplicitly]
-public class Application : ExternalApplication
+public class App : ExternalApplication
 {
     public override void OnStartup()
     {

--- a/source/Nice3point.Revit.AddIn.Application/Nice3point.Revit.AddIn.addin
+++ b/source/Nice3point.Revit.AddIn.Application/Nice3point.Revit.AddIn.addin
@@ -11,7 +11,7 @@
         <FullClassName>Nice3point.Revit.AddIn.Commands.StartupCommand</FullClassName>
         <Text>Nice3point.Revit.AddIn</Text>
 #elseif (Application)
-        <FullClassName>Nice3point.Revit.AddIn.Application</FullClassName>
+        <FullClassName>Nice3point.Revit.AddIn.App</FullClassName>
 #endif
         <VendorId>Development</VendorId>
         <VendorDescription></VendorDescription>


### PR DESCRIPTION
## Rename Application.cs class to avoid conflict with Revit API Application

- Renamed `Application `→ StartupApp in the ExternalApplication template
- Updated the corresponding FullClassName in .addin file templates.

The class name `Application ` could cause conflicts with `Autodesk.Revit.ApplicationServices.Application` when used in .addin files, potentially resulting in runtime loading errors.
Renaming it to StartupApp helps avoid naming ambiguity and improves compatibility and stability when loading Revit add-ins.