### PR TITLE
replace View call with ShowModal

### DIFF
--- a/samples/MultiProjectSolution/source/RevitAddIn/Commands/ShowModalWindowCommand.cs
+++ b/samples/MultiProjectSolution/source/RevitAddIn/Commands/ShowModalWindowCommand.cs
@@ -14,6 +14,6 @@ public class ShowModalWindowCommand : ExternalCommand
     public override void Execute()
     {
         var view = Host.CreateScope<ModalModuleView>();
-        view.Show();
+        view.ShowDialog();
     }
 }


### PR DESCRIPTION
# Fix modal window behavior in MultiProjectSolution sample

While testing the MultiProjectSolution sample, I found that a window intended to be displayed as a modal dialog was being opened as a modeless window.

The issue originated from Command.cs, where Show() was used to open the window. This PR changes the call to ShowModal() to ensure the expected modal behavior.


